### PR TITLE
Bump shiro.version from 1.4.0 to 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<java.version>1.8</java.version>
 		<mybatisplus.version>3.2.0</mybatisplus.version>
 		<druid.version>1.1.20</druid.version>
-		<shiro.version>1.4.0</shiro.version>
+		<shiro.version>1.7.1</shiro.version>
 		<log4j.version>1.2.17</log4j.version>
 		<hutool.version>4.6.8</hutool.version>
 		<pinyin4j.version>2.5.1</pinyin4j.version>


### PR DESCRIPTION
Bumps `shiro.version` from 1.4.0 to 1.7.1.

Updates `shiro-spring` from 1.4.0 to 1.7.1

Updates `shiro-core` from 1.4.0 to 1.7.1
- [Release notes](https://github.com/apache/shiro/releases)
- [Changelog](https://github.com/apache/shiro/blob/main/RELEASE-NOTES)
- [Commits](https://github.com/apache/shiro/compare/shiro-root-1.4.0...shiro-root-1.7.1)

Signed-off-by: dependabot[bot] <support@github.com>